### PR TITLE
Strip out any dots in the WSDL binding for the package name.

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -155,7 +155,7 @@ func (ge *goEncoder) encode(w io.Writer, d *wsdl.Definitions) error {
 	ge.cacheFuncs(d)
 	ge.cacheMessages(d)
 	ge.cacheSOAPOperations(d)
-	pkg := strings.ToLower(d.Binding.Name)
+	pkg := ge.formatPackageName(d.Binding.Name)
 	if pkg == "" {
 		pkg = "internal"
 	}
@@ -198,6 +198,10 @@ func (ge *goEncoder) encode(w io.Writer, d *wsdl.Definitions) error {
 	}
 	_, err = io.Copy(w, &b)
 	return err
+}
+
+func (ge *goEncoder) formatPackageName(pkg string) string {
+	return strings.Replace(strings.ToLower(pkg), ".", "", -1)
 }
 
 func (ge *goEncoder) importParts(d *wsdl.Definitions) error {

--- a/wsdlgo/testdata/memcache.wsdl
+++ b/wsdlgo/testdata/memcache.wsdl
@@ -85,7 +85,7 @@
       </operation>
    </portType>
 
-   <binding name="MemoryService" type="tns:MemoryServicePortType">
+   <binding name="Memory.Service" type="tns:MemoryServicePortType">
       <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
       <operation name="Get">
          <soap:operation soapAction="Get"/>


### PR DESCRIPTION
Closes #18.