### PR TITLE
Fix incorrect using of WSDL methods

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/fiorix/wsdl2go/wsdl"
-	"github.com/fiorix/wsdl2go/wsdlgo"
+	"github.com/retailnext/wsdl2go/wsdl"
+	"github.com/retailnext/wsdl2go/wsdlgo"
 )
 
 var version = "tip"

--- a/soap/client.go
+++ b/soap/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 )
 
 // A RoundTripper executes a request passing the given req as the SOAP
@@ -92,7 +91,7 @@ func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) err
 }
 
 // RoundTrip implements the RoundTripper interface.
-func (c *Client) RoundTrip(in, out Message) error {
+func (c *Client) RoundTrip(soapAction string, in, out Message) error {
 	headerFunc := func(r *http.Request) {
 		ct := c.ContentType
 		if ct == "" {
@@ -100,7 +99,7 @@ func (c *Client) RoundTrip(in, out Message) error {
 		}
 		r.Header.Set("Content-Type", ct)
 		if in != nil {
-			r.Header.Add("SOAPAction", fmt.Sprintf("%s/%s", c.Namespace, reflect.TypeOf(in).Elem().Name()))
+			r.Header.Add("SOAPAction", fmt.Sprintf("%s/%s", c.Namespace, soapAction))
 		}
 	}
 	return doRoundTrip(c, headerFunc, in, out)

--- a/soap/client_test.go
+++ b/soap/client_test.go
@@ -1,12 +1,12 @@
 package soap
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
-	"fmt"
 )
 
 func TestRoundTrip(t *testing.T) {
@@ -28,27 +28,31 @@ func TestRoundTrip(t *testing.T) {
 	pre := func(r *http.Request) { r.Header.Set("X-Test", "true") }
 	cases := []struct {
 		C       *Client
+		Action  string
 		In, Out Message
 		Fail    bool
 	}{
 		{
-			C:   &Client{URL: s.URL, Pre: pre},
-			In:  &msgT{A: "hello", B: "world"},
-			Out: &envT{},
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "hello",
+			In:     &msgT{A: "hello", B: "world"},
+			Out:    &envT{},
 		},
 		{
-			C:   &Client{URL: s.URL, Pre: pre},
-			In:  &msgT{A: "foo", B: "bar"},
-			Out: &envT{},
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "foo",
+			In:     &msgT{A: "foo", B: "bar"},
+			Out:    &envT{},
 		},
 		{
-			C:    &Client{URL: "", Pre: pre},
-			Out:  &envT{},
-			Fail: true,
+			C:      &Client{URL: "", Pre: pre},
+			Action: "none",
+			Out:    &envT{},
+			Fail:   true,
 		},
 	}
 	for i, tc := range cases {
-		err := tc.C.RoundTrip(tc.In, tc.Out)
+		err := tc.C.RoundTrip(tc.Action, tc.In, tc.Out)
 		if err != nil && !tc.Fail {
 			t.Errorf("test %d: %v", i, err)
 			continue

--- a/wsdl/types.go
+++ b/wsdl/types.go
@@ -203,8 +203,8 @@ type BindingOperation struct {
 // Soap12Operation.SoapAction is used to switch things over to sending
 // a soap 1.2 content type header (application/xml; charset=UTF-8; action='blah')
 type Soap12Operation struct {
-	XMLName    xml.Name   `xml:"http://schemas.xmlsoap.org/wsdl/soap12/ operation"`
-	SoapAction string     `xml:"soapAction,attr"`
+	XMLName    xml.Name `xml:"http://schemas.xmlsoap.org/wsdl/soap12/ operation"`
+	SoapAction string   `xml:"soapAction,attr"`
 }
 
 // BindingIO describes the IO binding of SOAP operations. See IO for details.

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/fiorix/wsdl2go/wsdl"
+	"github.com/retailnext/wsdl2go/wsdl"
 )
 
 // An Encoder generates Go code from WSDL definitions.
@@ -492,7 +492,7 @@ var soapFuncT = template.Must(template.New("soapFunc").Parse(
 			M {{.OutputType}} ` + "`xml:\"{{.XMLOutputType}}\"`" + `
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("{{.Name}}", α, &γ); err != nil {
 		return {{.RetDef}}, err
 	}
 	return {{if .RetPtr}}&{{end}}γ.Body.M, nil
@@ -523,7 +523,7 @@ func (ge *goEncoder) writeSOAPFunc(w io.Writer, d *wsdl.Definitions, op *wsdl.Op
 		return false
 	}
 	ge.needsStdPkg["encoding/xml"] = true
-	ge.needsExtPkg["github.com/fiorix/wsdl2go/soap"] = true
+	ge.needsExtPkg["github.com/retailnext/wsdl2go/soap"] = true
 	in[0] = renameParam(in[0], "α")
 	out[0] = renameParam(out[0], "β")
 	typ := strings.SplitN(out[0], " ", 2)
@@ -579,7 +579,6 @@ func (ge *goEncoder) writeSOAPFunc(w io.Writer, d *wsdl.Definitions, op *wsdl.Op
 	})
 	return true
 }
-
 
 func renameParam(p, name string) string {
 	v := strings.SplitN(p, " ", 2)
@@ -666,7 +665,12 @@ func (ge *goEncoder) genParams(m *wsdl.Message, needsTag bool) []*parameter {
 			t = ge.wsdl2goType(param.Type)
 			token = t
 		case param.Element != "":
-			t = ge.wsdl2goType(param.Element)
+			el_name := ge.trimns(param.Element)
+			if el, ok := ge.elements[el_name]; ok {
+				t = ge.wsdl2goType(ge.trimns(el.Type))
+			} else {
+				t = ge.wsdl2goType(param.Element)
+			}
 			token = ge.trimns(param.Element)
 		}
 		name := param.Name

--- a/wsdlgo/encoder_test.go
+++ b/wsdlgo/encoder_test.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/fiorix/wsdl2go/wsdl"
+	"github.com/retailnext/wsdl2go/wsdl"
 )
 
 func LoadDefinition(t *testing.T, filename string, want error) *wsdl.Definitions {

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -3,7 +3,7 @@ package dataendpointhttpbinding
 import (
 	"encoding/xml"
 
-	"github.com/fiorix/wsdl2go/soap"
+	"github.com/retailnext/wsdl2go/soap"
 )
 
 // Namespace was auto-generated from WSDL.
@@ -72,7 +72,7 @@ func (p *dataEndpointPortType) GetData(α *GetData) (β *GetDataResp, err error)
 			M GetDataResp `xml:"getDataResp"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetData", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/memcache.golden
+++ b/wsdlgo/testdata/memcache.golden
@@ -3,7 +3,7 @@ package memoryservice
 import (
 	"encoding/xml"
 
-	"github.com/fiorix/wsdl2go/soap"
+	"github.com/retailnext/wsdl2go/soap"
 )
 
 // Namespace was auto-generated from WSDL.
@@ -68,7 +68,7 @@ func (p *memoryServicePortType) Get(α string) (β *GetResponse, err error) {
 			M GetResponse `xml:"GetResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("Get", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -82,7 +82,7 @@ func (p *memoryServicePortType) GetMulti(α *GetMultiRequest) (β *GetMultiRespo
 			M GetMultiResponse `xml:"GetMultiResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetMulti", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -96,7 +96,7 @@ func (p *memoryServicePortType) Set(α *SetRequest) (β bool, err error) {
 			M bool `xml:"bool"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("Set", α, &γ); err != nil {
 		return false, err
 	}
 	return γ.Body.M, nil

--- a/wsdlgo/testdata/soap12wcf.golden
+++ b/wsdlgo/testdata/soap12wcf.golden
@@ -3,7 +3,7 @@ package testsoap12binding
 import (
 	"encoding/xml"
 
-	"github.com/fiorix/wsdl2go/soap"
+	"github.com/retailnext/wsdl2go/soap"
 )
 
 // Namespace was auto-generated from WSDL.
@@ -18,7 +18,7 @@ func NewTest(cli *soap.Client) Test {
 // and defines interface for the remote service. Useful for testing.
 type Test interface {
 	// HelloWorld was auto-generated from WSDL.
-	HelloWorld(α *HelloRequest) (β *HelloResponse, err error)
+	HelloWorld(α string) (β string, err error)
 }
 
 // test implements the Test interface.
@@ -27,15 +27,15 @@ type test struct {
 }
 
 // HelloWorld was auto-generated from WSDL.
-func (p *test) HelloWorld(α *HelloRequest) (β *HelloResponse, err error) {
+func (p *test) HelloWorld(α string) (β string, err error) {
 	γ := struct {
 		XMLName xml.Name `xml:"Envelope"`
 		Body    struct {
-			M HelloResponse `xml:"HelloResponse"`
+			M string `xml:"HelloResponse"`
 		}
 	}{}
 	if err = p.cli.RoundTripSoap12("http://example.com/Test/HelloWorldRequest", α, &γ); err != nil {
-		return nil, err
+		return "", err
 	}
-	return &γ.Body.M, nil
+	return γ.Body.M, nil
 }

--- a/wsdlgo/testdata/w3example1.golden
+++ b/wsdlgo/testdata/w3example1.golden
@@ -3,7 +3,7 @@ package endorsementsearchsoapbinding
 import (
 	"encoding/xml"
 
-	"github.com/fiorix/wsdl2go/soap"
+	"github.com/retailnext/wsdl2go/soap"
 )
 
 // Namespace was auto-generated from WSDL.
@@ -51,7 +51,7 @@ func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(α *GetEndorsingBoarde
 			M GetEndorsingBoarderResponse `xml:"GetEndorsingBoarderResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetEndorsingBoarder", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/w3example2.golden
+++ b/wsdlgo/testdata/w3example2.golden
@@ -3,7 +3,7 @@ package stockquotesoapbinding
 import (
 	"encoding/xml"
 
-	"github.com/fiorix/wsdl2go/soap"
+	"github.com/retailnext/wsdl2go/soap"
 )
 
 // Namespace was auto-generated from WSDL.
@@ -45,7 +45,7 @@ func (p *stockQuotePortType) GetLastTradePrice(α *TradePriceRequest) (β *Trade
 			M TradePrice `xml:"TradePrice"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil


### PR DESCRIPTION
- Pass SOAP action as argument to SOAP client, since it's
  a wrong to use WSDL message parameter name as SOAP action
  It may have a few parameters, so the SOAP action is the name of
  WSDL operation
- Fix wsdl function parameter type to use the type name like in WSDL
  Before it generated wsdl function with type as WSDL message.name

Signed-off-by: Artem Lobanov <artem@retailnext.net>