### PR TITLE
Parsing attributes and abstract types

### DIFF
--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -24,6 +24,7 @@ type DataEndpointPortType interface {
 // BaseReq was auto-generated from WSDL.
 type BaseReq struct {
 	ClientIdentification *ClientIdentification `xml:"clientIdentification,omitempty" json:"clientIdentification,omitempty" yaml:"clientIdentification,omitempty"`
+	TestAttr             string                `xml:"TestAttr,attr,omitempty" json:"TestAttr,attr,omitempty" yaml:"TestAttr,attr,omitempty"`
 }
 
 // BaseResp was auto-generated from WSDL.
@@ -35,17 +36,34 @@ type BaseResp struct {
 // DataGenerationReq was auto-generated from WSDL.
 type DataGenerationReq struct {
 	ClientIdentification  *ClientIdentification `xml:"clientIdentification,omitempty" json:"clientIdentification,omitempty" yaml:"clientIdentification,omitempty"`
+	TestAttr              string                `xml:"TestAttr,attr,omitempty" json:"TestAttr,attr,omitempty" yaml:"TestAttr,attr,omitempty"`
 	CustomerAccountNumber string                `xml:"customerAccountNumber,omitempty" json:"customerAccountNumber,omitempty" yaml:"customerAccountNumber,omitempty"`
 	PdfGenerationReqType  int                   `xml:"pdfGenerationReqType,omitempty" json:"pdfGenerationReqType,omitempty" yaml:"pdfGenerationReqType,omitempty"`
 	WithCreditTranferForm bool                  `xml:"withCreditTranferForm,omitempty" json:"withCreditTranferForm,omitempty" yaml:"withCreditTranferForm,omitempty"`
+	TypeAttrXSI           string                `xml:"xsi:type,attr,omitempty"`
+	TypeNamespace         string                `xml:"xmlns:objtype,attr,omitempty"`
+}
+
+// SetXMLType was auto-generated from WSDL.
+func (t *DataGenerationReq) SetXMLType() {
+	t.TypeAttrXSI = "objtype:DataGenerationReq"
+	t.TypeNamespace = "http://pdf.host.com/xsd"
 }
 
 // DataGenerationResp was auto-generated from WSDL.
 type DataGenerationResp struct {
-	ErrorDetails *ErrorDetails `xml:"errorDetails,omitempty" json:"errorDetails,omitempty" yaml:"errorDetails,omitempty"`
-	Success      bool          `xml:"success,omitempty" json:"success,omitempty" yaml:"success,omitempty"`
-	Pdf          []byte        `xml:"pdf,omitempty" json:"pdf,omitempty" yaml:"pdf,omitempty"`
-	Url          string        `xml:"url,omitempty" json:"url,omitempty" yaml:"url,omitempty"`
+	ErrorDetails  *ErrorDetails `xml:"errorDetails,omitempty" json:"errorDetails,omitempty" yaml:"errorDetails,omitempty"`
+	Success       bool          `xml:"success,omitempty" json:"success,omitempty" yaml:"success,omitempty"`
+	Pdf           []byte        `xml:"pdf,omitempty" json:"pdf,omitempty" yaml:"pdf,omitempty"`
+	Url           string        `xml:"url,omitempty" json:"url,omitempty" yaml:"url,omitempty"`
+	TypeAttrXSI   string        `xml:"xsi:type,attr,omitempty"`
+	TypeNamespace string        `xml:"xmlns:objtype,attr,omitempty"`
+}
+
+// SetXMLType was auto-generated from WSDL.
+func (t *DataGenerationResp) SetXMLType() {
+	t.TypeAttrXSI = "objtype:DataGenerationResp"
+	t.TypeNamespace = "http://pdf.host.com/xsd"
 }
 
 // GetData was auto-generated from WSDL.

--- a/wsdlgo/testdata/data.wsdl
+++ b/wsdlgo/testdata/data.wsdl
@@ -23,6 +23,7 @@
                 <xs:sequence>
                     <xs:element minOccurs="0" name="clientIdentification" nillable="true" type="ax2179:ClientIdentification"/>
                 </xs:sequence>
+                <xs:attribute name="TestAttr" type="xs:string"></xs:attribute>
             </xs:complexType>
             <xs:complexType name="BaseResp">
                 <xs:sequence>


### PR DESCRIPTION
- Add supporting XML attributes
- Add supporting XML abstract types.  Set xml "xsi:type" attribute. It contains the certain XML type. For each xml type is inherited from xml abstract type new Go function `SetXMLType` is generated. This function is called in soap client to fill `TypeAttrXSI` of Go struct. This field is used in XML Marshalling and it contains the actual xml type of the object.
- Add supporting nested imported namespaces. Example:
  `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="urn:sales_2016_2.transactions.webservices.netsuite.com" elementFormDefault="qualified">
    <xsd:import namespace="nested_1" schemaLocation="nested_1.xsd"/>
    <xsd:import namespace="nested_2" schemaLocation="nested_2.xsd"/>
    <xsd:import namespace="urn:common_2016_2.platform.webservices.netsuite.com" schemaLocation="platform.common.xsd"/>`
Before all information from `import` were absent.