### PR TITLE
Fixed SetXMLType's receiver name in genGoXMLTypeFunction

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1014,7 +1014,7 @@ func (ge *goEncoder) genGoXMLTypeFunction(w io.Writer, ct *wsdl.ComplexType) {
 	ext := ct.ComplexContent.Extension
 	if ext.Base != "" {
 		ge.writeComments(w, "SetXMLType", "")
-		fmt.Fprintf(w, "func (t *%s) SetXMLType() {\n", ct.Name)
+		fmt.Fprintf(w, "func (t *%s) SetXMLType() {\n", strings.Title(ct.Name))
 		fmt.Fprintf(w, "t.TypeAttrXSI = \"objtype:%s\"\n", ct.Name)
 		fmt.Fprintf(w, "t.TypeNamespace = \"%s\"\n}\n\n", ct.TargetNamespace)
 	}


### PR DESCRIPTION
https://github.com/fiorix/wsdl2go/blob/798469e1c87b2935f7377d53ef2b549fcb3c308e/wsdlgo/encoder.go#L1017
I guess it's wrong, because generated code is like this:
```go
type FooBar struct {
	// ...
}

func (t *fooBar) SetXMLType() {
	t.TypeAttrXSI = "objtype:fooBar"
	// ...
}
```