### PR TITLE
[Ready] Added http.Client factory that creates client with default options

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,15 +85,8 @@ func open(name string, cli *http.Client) (io.ReadCloser, error) {
 
 // httpClient returns http client with default options
 func httpClient(insecure bool) *http.Client {
-	defaultTransport := http.DefaultTransport.(*http.Transport)
-	transport := &http.Transport{
-		Proxy:                 defaultTransport.Proxy,
-		DialContext:           defaultTransport.DialContext,
-		MaxIdleConns:          defaultTransport.MaxIdleConns,
-		IdleConnTimeout:       defaultTransport.IdleConnTimeout,
-		ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
-		TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: insecure},
-	}
-	return &http.Client{Transport: transport}
+	transport := *(http.DefaultTransport.(*http.Transport))
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+
+	return &http.Client{Transport: &transport}
 }


### PR DESCRIPTION
The problem: if we try to use `-yolo` option it will create new instance of http.Transport instead of `http.DefaultTransport` that used by default. But `http.DefaultTransport` use `ProxyFromEnvironment` to transparently handle proxy setting. As result we can't go through proxy anymore.

This factory will create a new transport with all default options from `http.DefaultTransport` except TLSClientConfig which is responsible for accepting invalid certificates. So the proxy handling will be kept.