### PR TITLE
[Ready] Fixed generation of messages with no params

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1044,7 +1044,12 @@ func (ge *goEncoder) genGoStruct(w io.Writer, d *wsdl.Definitions, ct *wsdl.Comp
 		return nil
 	}
 	if c > 2 {
-		fmt.Fprintf(w, "type %s struct {}\n\n", name)
+		fmt.Fprintf(w, "type %s struct {\n", name)
+		if elName, ok := ge.needsTag[name]; ok {
+			fmt.Fprintf(w, "XMLName xml.Name `xml:\"%s %s\" json:\"-\" yaml:\"-\"`\n",
+				d.TargetNamespace, elName)
+		}
+		fmt.Fprintf(w, "}\n\n")
 		return nil
 	}
 	fmt.Fprintf(w, "type %s struct {\n", name)

--- a/wsdlgo/testdata/w3cexample1.golden
+++ b/wsdlgo/testdata/w3cexample1.golden
@@ -5,7 +5,17 @@ import (
 	"errors"
 )
 
+// GetNothing was auto-generated from WSDL.
+func GetNothing(ctx context.Context, something string) (err error) {
+	return errors.New("not implemented")
+}
+
 // GetTerm was auto-generated from WSDL.
 func GetTerm(ctx context.Context, term string) (value string, err error) {
 	return "", errors.New("not implemented")
+}
+
+// GetVoid was auto-generated from WSDL.
+func GetVoid(ctx context.Context, something string) (err error) {
+	return errors.New("not implemented")
 }

--- a/wsdlgo/testdata/w3cexample1.wsdl
+++ b/wsdlgo/testdata/w3cexample1.wsdl
@@ -1,18 +1,31 @@
 <definitions>
+    <message name="getTermRequest">
+        <part name="term" type="xs:string"/>
+    </message>
 
-<message name="getTermRequest">
-  <part name="term" type="xs:string"/>
-</message>
+    <message name="getTermResponse">
+        <part name="value" type="xs:string"/>
+    </message>
 
-<message name="getTermResponse">
-  <part name="value" type="xs:string"/>
-</message>
+    <message name="getNothingRequest">
+        <part name="something" type="xs:string"/>
+    </message>
 
-<portType name="glossaryTerms">
-  <operation name="getTerm">
-    <input message="getTermRequest"/>
-    <output message="getTermResponse"/>
-  </operation>
-</portType>
+    <message name="getNothingResponse"/>
 
+    <portType name="glossaryTerms">
+        <operation name="getTerm">
+            <input message="getTermRequest"/>
+            <output message="getTermResponse"/>
+        </operation>
+
+        <operation name="getNothing">
+            <input message="getNothingRequest"/>
+            <output message="getNothingResponse"/>
+        </operation>
+
+        <operation name="getVoid">
+            <input message="getNothingRequest"/>
+        </operation>
+    </portType>
 </definitions>

--- a/wsdlgo/testdata/w3cexample2.golden
+++ b/wsdlgo/testdata/w3cexample2.golden
@@ -5,6 +5,16 @@ import (
 	"errors"
 )
 
+// DoNothing was auto-generated from WSDL.
+func DoNothing(ctx context.Context) (err error) {
+	return errors.New("not implemented")
+}
+
+// SetNothing was auto-generated from WSDL.
+func SetNothing(ctx context.Context) (err error) {
+	return errors.New("not implemented")
+}
+
 // SetTerm was auto-generated from WSDL.
 func SetTerm(ctx context.Context, term string, value string) (err error) {
 	return errors.New("not implemented")

--- a/wsdlgo/testdata/w3cexample2.wsdl
+++ b/wsdlgo/testdata/w3cexample2.wsdl
@@ -1,14 +1,20 @@
 <definitions>
+    <message name="newTermValues">
+        <part name="term" type="xs:string"/>
+        <part name="value" type="xs:string"/>
+    </message>
 
-<message name="newTermValues">
-  <part name="term" type="xs:string"/>
-  <part name="value" type="xs:string"/>
-</message>
+    <message name="nothingRequest"/>
 
-<portType name="glossaryTerms">
-  <operation name="setTerm">
-    <input name="newTerm" message="newTermValues"/>
-  </operation>
-</portType >
+    <portType name="glossaryTerms">
+        <operation name="setTerm">
+            <input name="newTerm" message="newTermValues"/>
+        </operation>
 
+        <operation name="setNothing">
+            <input name="something" message="nothingRequest"/>
+        </operation>
+
+        <operation name="doNothing"/>
+    </portType>
 </definitions>

--- a/wsdlgo/testdata/w3example2.golden
+++ b/wsdlgo/testdata/w3example2.golden
@@ -17,8 +17,34 @@ func NewStockQuotePortType(cli *soap.Client) StockQuotePortType {
 // StockQuotePortType was auto-generated from WSDL
 // and defines interface for the remote service. Useful for testing.
 type StockQuotePortType interface {
+	// DestroySession was auto-generated from WSDL.
+	DestroySession(α *DestroySessionRequest) (β *DestroySessionResponse, err error)
+
 	// GetLastTradePrice was auto-generated from WSDL.
 	GetLastTradePrice(α *TradePriceRequest) (β *TradePrice, err error)
+
+	// GetSession was auto-generated from WSDL.
+	GetSession(α *GetSessionRequest) (β *GetSessionResponse, err error)
+}
+
+// DestroySessionRequest was auto-generated from WSDL.
+type DestroySessionRequest struct {
+	XMLName   xml.Name `xml:"http://example.com/stockquote.wsdl DestroySessionRequest" json:"-" yaml:"-"`
+	SessionId *string  `xml:"sessionId,omitempty" json:"sessionId,omitempty" yaml:"sessionId,omitempty"`
+}
+
+// DestroySessionResponse was auto-generated from WSDL.
+type DestroySessionResponse struct {
+}
+
+// GetSessionRequest was auto-generated from WSDL.
+type GetSessionRequest struct {
+	XMLName xml.Name `xml:"http://example.com/stockquote.wsdl GetSessionRequest" json:"-" yaml:"-"`
+}
+
+// GetSessionResponse was auto-generated from WSDL.
+type GetSessionResponse struct {
+	SessionId *string `xml:"sessionId,omitempty" json:"sessionId,omitempty" yaml:"sessionId,omitempty"`
 }
 
 // TradePrice was auto-generated from WSDL.
@@ -37,6 +63,20 @@ type stockQuotePortType struct {
 	cli *soap.Client
 }
 
+// DestroySession was auto-generated from WSDL.
+func (p *stockQuotePortType) DestroySession(α *DestroySessionRequest) (β *DestroySessionResponse, err error) {
+	γ := struct {
+		XMLName xml.Name `xml:"Envelope"`
+		Body    struct {
+			M DestroySessionResponse `xml:"DestroySessionResponse"`
+		}
+	}{}
+	if err = p.cli.RoundTripWithAction("DestroySession", α, &γ); err != nil {
+		return nil, err
+	}
+	return &γ.Body.M, nil
+}
+
 // GetLastTradePrice was auto-generated from WSDL.
 func (p *stockQuotePortType) GetLastTradePrice(α *TradePriceRequest) (β *TradePrice, err error) {
 	γ := struct {
@@ -46,6 +86,20 @@ func (p *stockQuotePortType) GetLastTradePrice(α *TradePriceRequest) (β *Trade
 		}
 	}{}
 	if err = p.cli.RoundTripWithAction("GetLastTradePrice", α, &γ); err != nil {
+		return nil, err
+	}
+	return &γ.Body.M, nil
+}
+
+// GetSession was auto-generated from WSDL.
+func (p *stockQuotePortType) GetSession(α *GetSessionRequest) (β *GetSessionResponse, err error) {
+	γ := struct {
+		XMLName xml.Name `xml:"Envelope"`
+		Body    struct {
+			M GetSessionResponse `xml:"GetSessionResponse"`
+		}
+	}{}
+	if err = p.cli.RoundTripWithAction("GetSession", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/w3example2.wsdl
+++ b/wsdlgo/testdata/w3example2.wsdl
@@ -37,6 +37,29 @@
               </xsd:complexType>
            </xsd:element>
 
+           <xsd:element name="GetSessionRequest">
+               <xsd:complexType/>
+           </xsd:element>
+
+           <xsd:element name="GetSessionResponse">
+               <xsd:complexType>
+                   <xsd:all>
+                       <xsd:element name="sessionId" type="string"/>
+                   </xsd:all>
+               </xsd:complexType>
+           </xsd:element>
+
+           <xsd:element name="DestroySessionRequest">
+               <xsd:complexType>
+                   <xsd:all>
+                       <xsd:element name="sessionId" type="string"/>
+                   </xsd:all>
+               </xsd:complexType>
+           </xsd:element>
+
+           <xsd:element name="DestroySessionResponse">
+               <xsd:complexType/>
+           </xsd:element>
        </xsd:schema>
     </wsdl:types>
 
@@ -50,6 +73,24 @@
         <wsdl:part name="body" element="xsd1:TradePrice"/>
     </wsdl:message>
 
+    <wsdl:message name="GetSessionInput">
+        <wsdl:part name="body" element="xsd1:GetSessionRequest"/>
+    </wsdl:message>
+
+    <!-- request GetSessionOutput is of type GetSessionResponse -->
+    <wsdl:message name="GetSessionOutput">
+        <wsdl:part name="body" element="xsd1:GetSessionResponse"/>
+    </wsdl:message>
+
+    <wsdl:message name="DestroySessionInput">
+        <wsdl:part name="body" element="xsd1:DestroySessionRequest"/>
+    </wsdl:message>
+
+    <!-- request DestroySessionOutput is of type DestroySessionResponse -->
+    <wsdl:message name="DestroySessionOutput">
+        <wsdl:part name="body" element="xsd1:DestroySessionResponse"/>
+    </wsdl:message>
+
     <!-- wsdl:portType describes messages in an operation -->
     <wsdl:portType name="StockQuotePortType">
 
@@ -57,6 +98,16 @@
         <wsdl:operation name="GetLastTradePrice">
            <wsdl:input message="tns:GetLastTradePriceInput"/>
            <wsdl:output message="tns:GetLastTradePriceOutput"/>
+        </wsdl:operation>
+
+        <wsdl:operation name="GetSession">
+            <wsdl:input message="tns:GetSessionInput"/>
+            <wsdl:output message="tns:GetSessionOutput"/>
+        </wsdl:operation>
+
+        <wsdl:operation name="DestroySession">
+            <wsdl:input message="tns:DestroySessionInput"/>
+            <wsdl:output message="tns:DestroySessionOutput"/>
         </wsdl:operation>
     </wsdl:portType>
 
@@ -79,6 +130,30 @@
            <wsdl:output>
                <soap:body use="literal"/>
            </wsdl:output>
+        </wsdl:operation>
+
+        <wsdl:operation name="GetSession">
+            <!-- again bind to SOAP? @@@ -->
+            <soap:operation soapAction="http://example.com/GetSession"/>
+            <!-- furthur specify that the messages in the wsdl:operation "" use SOAP? @@@ -->
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+
+        <wsdl:operation name="DestroySession">
+            <!-- again bind to SOAP? @@@ -->
+            <soap:operation soapAction="http://example.com/DestroySession"/>
+            <!-- furthur specify that the messages in the wsdl:operation "" use SOAP? @@@ -->
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
 


### PR DESCRIPTION
Problem: if an operation has no input parameters, request message struct is empty
```go
type FooBar struct{}
```
and a soap xml becomes like
```xml
<SOAP-ENV:Body><Message></Message></SOAP-ENV:Body>
```
But it must be like
```xml
<SOAP-ENV:Body><fooBar xmlns="http://name/space/uri"></fooBar></SOAP-ENV:Body>
```
Even if request message has no params it must keep xml tag
```go
type FooBar struct {
    XMLName xml.Name `xml:"http://name/space/uri fooBar" json:"-" yaml:"-"`
}
```

