### PR TITLE
Fix #58 by limiting travis to 1.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 language: go
 
 go:
-  - 1.6
-  - 1.7
   - 1.8
   - 1.9
   - tip


### PR DESCRIPTION
I assume that we want to use the new golang test feature (such as test.Name etc.).  Thus, .travis should limit go version to 1.8+