### PR TITLE
Close #60 - go vet warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 
 language: go
 
+before_script:
+  - go vet ./...
+
 go:
   - 1.6
   - 1.7

--- a/main.go
+++ b/main.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"time"
 
 	"github.com/fiorix/wsdl2go/wsdl"
 	"github.com/fiorix/wsdl2go/wsdlgo"
@@ -97,19 +95,8 @@ func open(name string, cli *http.Client) (io.ReadCloser, error) {
 
 // httpClient returns http client with default options
 func httpClient(insecure bool) *http.Client {
-	transport := http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
+	client := &http.Client{}
+	transport := client.Transport.(*http.Transport)
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
-
-	return &http.Client{Transport: &transport}
+	return client
 }

--- a/main.go
+++ b/main.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/fiorix/wsdl2go/wsdl"
 	"github.com/fiorix/wsdl2go/wsdlgo"
@@ -95,7 +97,18 @@ func open(name string, cli *http.Client) (io.ReadCloser, error) {
 
 // httpClient returns http client with default options
 func httpClient(insecure bool) *http.Client {
-	transport := *(http.DefaultTransport.(*http.Transport))
+	transport := http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
 
 	return &http.Client{Transport: &transport}


### PR DESCRIPTION
Do not copy across http transport object as the internal implementation of DefaultTransport contains mutex.

Instead, initialise the return transport with the identical DefautlTransport value.