### PR TITLE
Close #68 by allowing overriding SetXMLTypes value.

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1025,8 +1025,16 @@ func (ge *goEncoder) genGoXMLTypeFunction(w io.Writer, ct *wsdl.ComplexType) {
 	if ext.Base != "" && !ct.Abstract {
 		ge.writeComments(w, "SetXMLType", "")
 		fmt.Fprintf(w, "func (t *%s) SetXMLType() {\n", strings.Title(ct.Name))
-		fmt.Fprintf(w, "t.TypeAttrXSI = \"objtype:%s\"\n", ct.Name)
-		fmt.Fprintf(w, "t.TypeNamespace = \"%s\"\n}\n\n", ct.TargetNamespace)
+		fmt.Fprintf(w, "if t.OverrideTypeAttrXSI != nil {\n")
+		fmt.Fprintf(w, "    t.TypeAttrXSI = *t.OverrideTypeAttrXSI\n")
+		fmt.Fprintf(w, "} else {\n")
+		fmt.Fprintf(w, "    t.TypeAttrXSI = \"objtype:%s\"\n", ct.Name)
+		fmt.Fprintf(w, "}\n")
+		fmt.Fprintf(w, "if t.OverrideTypeNamespace != nil {\n")
+		fmt.Fprintf(w, "    t.TypeNamespace = *t.OverrideTypeNamespace\n")
+		fmt.Fprintf(w, "} else {\n")
+		fmt.Fprintf(w, "    t.TypeNamespace = \"%s\"\n", ct.TargetNamespace)
+		fmt.Fprintf(w, "}\n}\n\n")
 	}
 }
 
@@ -1072,6 +1080,9 @@ func (ge *goEncoder) genGoStruct(w io.Writer, d *wsdl.Definitions, ct *wsdl.Comp
 	if ct.ComplexContent != nil && ct.ComplexContent.Extension != nil {
 		fmt.Fprint(w, "TypeAttrXSI   string `xml:\"xsi:type,attr,omitempty\"`\n")
 		fmt.Fprint(w, "TypeNamespace string `xml:\"xmlns:objtype,attr,omitempty\"`\n")
+		fmt.Fprint(w, "\n")
+		fmt.Fprint(w, "OverrideTypeAttrXSI   *string `xml:\"-\"`\n")
+		fmt.Fprint(w, "OverrideTypeNamespace *string `xml:\"-\"`\n")
 	}
 	if err != nil {
 		return err

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -42,12 +42,23 @@ type DataGenerationReq struct {
 	WithCreditTranferForm *bool                 `xml:"withCreditTranferForm,omitempty" json:"withCreditTranferForm,omitempty" yaml:"withCreditTranferForm,omitempty"`
 	TypeAttrXSI           string                `xml:"xsi:type,attr,omitempty"`
 	TypeNamespace         string                `xml:"xmlns:objtype,attr,omitempty"`
+
+	OverrideTypeAttrXSI   *string `xml:"-"`
+	OverrideTypeNamespace *string `xml:"-"`
 }
 
 // SetXMLType was auto-generated from WSDL.
 func (t *DataGenerationReq) SetXMLType() {
-	t.TypeAttrXSI = "objtype:DataGenerationReq"
-	t.TypeNamespace = "http://pdf.host.com/xsd"
+	if t.OverrideTypeAttrXSI != nil {
+		t.TypeAttrXSI = *t.OverrideTypeAttrXSI
+	} else {
+		t.TypeAttrXSI = "objtype:DataGenerationReq"
+	}
+	if t.OverrideTypeNamespace != nil {
+		t.TypeNamespace = *t.OverrideTypeNamespace
+	} else {
+		t.TypeNamespace = "http://pdf.host.com/xsd"
+	}
 }
 
 // DataGenerationResp was auto-generated from WSDL.
@@ -58,12 +69,23 @@ type DataGenerationResp struct {
 	Url           *string       `xml:"url,omitempty" json:"url,omitempty" yaml:"url,omitempty"`
 	TypeAttrXSI   string        `xml:"xsi:type,attr,omitempty"`
 	TypeNamespace string        `xml:"xmlns:objtype,attr,omitempty"`
+
+	OverrideTypeAttrXSI   *string `xml:"-"`
+	OverrideTypeNamespace *string `xml:"-"`
 }
 
 // SetXMLType was auto-generated from WSDL.
 func (t *DataGenerationResp) SetXMLType() {
-	t.TypeAttrXSI = "objtype:DataGenerationResp"
-	t.TypeNamespace = "http://pdf.host.com/xsd"
+	if t.OverrideTypeAttrXSI != nil {
+		t.TypeAttrXSI = *t.OverrideTypeAttrXSI
+	} else {
+		t.TypeAttrXSI = "objtype:DataGenerationResp"
+	}
+	if t.OverrideTypeNamespace != nil {
+		t.TypeNamespace = *t.OverrideTypeNamespace
+	} else {
+		t.TypeNamespace = "http://pdf.host.com/xsd"
+	}
 }
 
 // GetData was auto-generated from WSDL.


### PR DESCRIPTION
Allow caller to override the values that will be set the in the SetXMLTypes function.
If OverrideTypeAttrXSI and/or OverrideTypeNamespace is set, then
the function SetXMLType will use that value.  Otherwise, it will use the default
generated values