### PR TITLE
Fix issue #78

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -691,8 +691,11 @@ func (ge *goEncoder) writeSOAPFunc(w io.Writer, d *wsdl.Definitions, op *wsdl.Op
 		operationOutputPrefixes[index] = ""
 		retDefaults[index] = "nil"
 
+		// If the output is >not< a pointer, we need to return the value of the response
 		if !strings.HasPrefix(name.dataType, "*") {
 			operationOutputPrefixes[index] = "*"
+
+			// Also - only resolve the default for non-pointer returns (otherwise nil suffices)
 			retDefaults[index] = ge.wsdl2goDefault(name.dataType)
 		}
 	}
@@ -1037,7 +1040,7 @@ func (ge *goEncoder) wsdl2goDefault(t string) string {
 		return "0"
 	case "string":
 		return `""`
-	case "[]byte":
+	case "[]byte", "interface{}":
 		return "nil"
 	default:
 		return "&" + v + "{}"


### PR DESCRIPTION
Along the way of https://github.com/fiorix/wsdl2go/pull/75 the correct default value for an interface{} type was lost. This causes default returns such as &interface{}{} mentioned in https://github.com/fiorix/wsdl2go/issues/78.

@Fank can we use the wsdls you provided as test-cases?