### PR TITLE
Fix #86 by fixing non-rpc request and response marshalling regression

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -682,20 +682,17 @@ func (ge *goEncoder) writeSOAPFunc(w io.Writer, d *wsdl.Definitions, op *wsdl.Op
 	}
 	retDefaults[len(retDefaults)-1] = "err"
 
-	// Check if we need to outline the op and prefix with a namespace
-	namespacedOpName := "-"
-	opResponseName := "-"
-	if rpcStyle {
-		// Check if we need to prefix the op with a namespace
-		namespacedOpName = op.Name
-		nsSplit := strings.Split(ge.funcs[op.Name].Input.Message, ":")
-		if len(nsSplit) > 1 {
-			namespacedOpName = nsSplit[0] + ":" + namespacedOpName
-		}
-
-		// The response name is always the operation name + "Response" according to specification
-		opResponseName = fmt.Sprintf("%sResponse", op.Name)
+	// Check if we need to prefix the op with a namespace
+	namespacedOpName := op.Name
+	nsSplit := strings.Split(ge.funcs[op.Name].Input.Message, ":")
+	if len(nsSplit) > 1 {
+		namespacedOpName = nsSplit[0] + ":" + namespacedOpName
 	}
+
+	// The response name is always the operation name + "Response" according to specification.
+	// Note, we also omit the namespace, since this does currently not work reliable with golang
+	// (See: https://github.com/golang/go/issues/14407)
+	opResponseName := op.Name + "Response"
 
 	// No-input operations can be inlined into an anonymous struct on rpc, and omitted otherwise
 	operationInputDataType := ""

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -116,7 +116,7 @@ type dataEndpointPortType struct {
 // GetData was auto-generated from WSDL.
 func (p *dataEndpointPortType) GetData(parameters *GetData) (*GetDataResp, error) {
 	α := struct {
-		OperationGetDataReq `xml:"-"`
+		OperationGetDataReq `xml:"ns:getData"`
 	}{
 		OperationGetDataReq{
 			parameters,
@@ -124,7 +124,7 @@ func (p *dataEndpointPortType) GetData(parameters *GetData) (*GetDataResp, error
 	}
 
 	γ := struct {
-		OperationGetDataResp `xml:"-"`
+		OperationGetDataResp `xml:"getDataResponse"`
 	}{}
 	if err := p.cli.RoundTripWithAction("GetData", α, &γ); err != nil {
 		return nil, err

--- a/wsdlgo/testdata/data_withkeyword.golden
+++ b/wsdlgo/testdata/data_withkeyword.golden
@@ -116,7 +116,7 @@ type dataEndpointPortType struct {
 // GetData was auto-generated from WSDL.
 func (p *dataEndpointPortType) GetData(_return *GetData) (*GetDataResp, error) {
 	α := struct {
-		OperationGetDataReq `xml:"-"`
+		OperationGetDataReq `xml:"ns:getData"`
 	}{
 		OperationGetDataReq{
 			_return,
@@ -124,7 +124,7 @@ func (p *dataEndpointPortType) GetData(_return *GetData) (*GetDataResp, error) {
 	}
 
 	γ := struct {
-		OperationGetDataResp `xml:"-"`
+		OperationGetDataResp `xml:"getDataResponse"`
 	}{}
 	if err := p.cli.RoundTripWithAction("GetData", α, &γ); err != nil {
 		return nil, err

--- a/wsdlgo/testdata/localimport.golden
+++ b/wsdlgo/testdata/localimport.golden
@@ -49,7 +49,7 @@ type stockQuotePortType struct {
 // GetLastTradePrice was auto-generated from WSDL.
 func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradePrice, error) {
 	α := struct {
-		OperationGetLastTradePriceInput `xml:"-"`
+		OperationGetLastTradePriceInput `xml:"tns:GetLastTradePrice"`
 	}{
 		OperationGetLastTradePriceInput{
 			body,
@@ -57,7 +57,7 @@ func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradeP
 	}
 
 	γ := struct {
-		OperationGetLastTradePriceOutput `xml:"-"`
+		OperationGetLastTradePriceOutput `xml:"GetLastTradePriceResponse"`
 	}{}
 	if err := p.cli.RoundTripWithAction("http://example.com/GetLastTradePrice", α, &γ); err != nil {
 		return nil, err

--- a/wsdlgo/testdata/soap12wcf.golden
+++ b/wsdlgo/testdata/soap12wcf.golden
@@ -39,7 +39,7 @@ type test struct {
 // HelloWorld was auto-generated from WSDL.
 func (p *test) HelloWorld(parameters string) (string, error) {
 	α := struct {
-		OperationHelloWorldMessageIn `xml:"-"`
+		OperationHelloWorldMessageIn `xml:"tns:HelloWorld"`
 	}{
 		OperationHelloWorldMessageIn{
 			&parameters,
@@ -47,7 +47,7 @@ func (p *test) HelloWorld(parameters string) (string, error) {
 	}
 
 	γ := struct {
-		OperationHelloWorldMessageOut `xml:"-"`
+		OperationHelloWorldMessageOut `xml:"HelloWorldResponse"`
 	}{}
 	if err := p.cli.RoundTripSoap12("http://example.com/Test/HelloWorldRequest", α, &γ); err != nil {
 		return "", err

--- a/wsdlgo/testdata/w3example1.golden
+++ b/wsdlgo/testdata/w3example1.golden
@@ -57,7 +57,7 @@ type getEndorsingBoarderPortType struct {
 // GetEndorsingBoarder was auto-generated from WSDL.
 func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(body *GetEndorsingBoarder) (*GetEndorsingBoarderResponse, error) {
 	α := struct {
-		OperationGetEndorsingBoarderRequest `xml:"-"`
+		OperationGetEndorsingBoarderRequest `xml:"es:GetEndorsingBoarder"`
 	}{
 		OperationGetEndorsingBoarderRequest{
 			body,
@@ -65,7 +65,7 @@ func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(body *GetEndorsingBoar
 	}
 
 	γ := struct {
-		OperationGetEndorsingBoarderResponse `xml:"-"`
+		OperationGetEndorsingBoarderResponse `xml:"GetEndorsingBoarderResponse"`
 	}{}
 	if err := p.cli.RoundTripWithAction("http://www.snowboard-info.com/EndorsementSearch", α, &γ); err != nil {
 		return nil, err

--- a/wsdlgo/testdata/w3example2.golden
+++ b/wsdlgo/testdata/w3example2.golden
@@ -97,7 +97,7 @@ type stockQuotePortType struct {
 // DestroySession was auto-generated from WSDL.
 func (p *stockQuotePortType) DestroySession(body *DestroySessionRequest) (*DestroySessionResponse, error) {
 	α := struct {
-		OperationDestroySessionInput `xml:"-"`
+		OperationDestroySessionInput `xml:"tns:DestroySession"`
 	}{
 		OperationDestroySessionInput{
 			body,
@@ -105,7 +105,7 @@ func (p *stockQuotePortType) DestroySession(body *DestroySessionRequest) (*Destr
 	}
 
 	γ := struct {
-		OperationDestroySessionOutput `xml:"-"`
+		OperationDestroySessionOutput `xml:"DestroySessionResponse"`
 	}{}
 	if err := p.cli.RoundTripWithAction("http://example.com/DestroySession", α, &γ); err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (p *stockQuotePortType) DestroySession(body *DestroySessionRequest) (*Destr
 // GetLastTradePrice was auto-generated from WSDL.
 func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradePrice, error) {
 	α := struct {
-		OperationGetLastTradePriceInput `xml:"-"`
+		OperationGetLastTradePriceInput `xml:"tns:GetLastTradePrice"`
 	}{
 		OperationGetLastTradePriceInput{
 			body,
@@ -124,7 +124,7 @@ func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradeP
 	}
 
 	γ := struct {
-		OperationGetLastTradePriceOutput `xml:"-"`
+		OperationGetLastTradePriceOutput `xml:"GetLastTradePriceResponse"`
 	}{}
 	if err := p.cli.RoundTripWithAction("http://example.com/GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradeP
 // GetSession was auto-generated from WSDL.
 func (p *stockQuotePortType) GetSession(body *GetSessionRequest) (*GetSessionResponse, error) {
 	α := struct {
-		OperationGetSessionInput `xml:"-"`
+		OperationGetSessionInput `xml:"tns:GetSession"`
 	}{
 		OperationGetSessionInput{
 			body,
@@ -143,7 +143,7 @@ func (p *stockQuotePortType) GetSession(body *GetSessionRequest) (*GetSessionRes
 	}
 
 	γ := struct {
-		OperationGetSessionOutput `xml:"-"`
+		OperationGetSessionOutput `xml:"GetSessionResponse"`
 	}{}
 	if err := p.cli.RoundTripWithAction("http://example.com/GetSession", α, &γ); err != nil {
 		return nil, err


### PR DESCRIPTION
I don't know why I didn't see this when I was developing #75, and I'm terrible sorry for breaking this.

`xml:"-"` will cause the struct field to be dropped instead of inlined. The key is to either use composition (for non-rpc) or a field (for rpc). Note when looking at the golden files how some requests start with `M ....` (rpc), and some don't (non-rpc).

The xml tag is now always set, as it is ignored when using composition anyway (however - important as to not drop the object).

One can play around [with this](https://play.golang.org/p/KmxJK_YpL2o) (use locally, does not work in playground due to import). Look at line 121, and experiment with prefixing M to see how the xml request changes for rpc. Setting the xml in either line 121 or 129 to "-" (as was done prior to this PR), you will run into errors (wrong request marshalling, and panic for the response).