### PR TITLE
Array encoding, unsigned integer fix and Post hook in client

### DIFF
--- a/soap/client.go
+++ b/soap/client.go
@@ -42,15 +42,16 @@ type AuthHeader struct {
 
 // Client is a SOAP client.
 type Client struct {
-	URL                    string              // URL of the server
-	Namespace              string              // SOAP Namespace
-	ThisNamespace          string              // SOAP This-Namespace (tns)
-	ExcludeActionNamespace bool                // Include Namespace to SOAP Action header
-	Envelope               string              // Optional SOAP Envelope
-	Header                 Header              // Optional SOAP Header
-	ContentType            string              // Optional Content-Type (default text/xml)
-	Config                 *http.Client        // Optional HTTP client
-	Pre                    func(*http.Request) // Optional hook to modify outbound requests
+	URL                    string               // URL of the server
+	Namespace              string               // SOAP Namespace
+	ThisNamespace          string               // SOAP This-Namespace (tns)
+	ExcludeActionNamespace bool                 // Include Namespace to SOAP Action header
+	Envelope               string               // Optional SOAP Envelope
+	Header                 Header               // Optional SOAP Header
+	ContentType            string               // Optional Content-Type (default text/xml)
+	Config                 *http.Client         // Optional HTTP client
+	Pre                    func(*http.Request)  // Optional hook to modify outbound requests
+	Post                   func(*http.Response) // Optional hook to snoop inbound responses
 }
 
 // XMLTyper is an abstract interface for types that can set an XML type.
@@ -131,6 +132,9 @@ func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) err
 		return err
 	}
 	defer resp.Body.Close()
+	if c.Post != nil {
+		c.Post(resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		// read only the first MiB of the body in error case
 		limReader := io.LimitReader(resp.Body, 1024*1024)

--- a/wsdl/types.go
+++ b/wsdl/types.go
@@ -105,9 +105,10 @@ type Union struct {
 // Restriction describes the WSDL type of the simple type and
 // optionally its allowed values.
 type Restriction struct {
-	XMLName xml.Name `xml:"restriction"`
-	Base    string   `xml:"base,attr"`
-	Enum    []*Enum  `xml:"enumeration"`
+	XMLName    xml.Name     `xml:"restriction"`
+	Base       string       `xml:"base,attr"`
+	Enum       []*Enum      `xml:"enumeration"`
+	Attributes []*Attribute `xml:"attribute"`
 }
 
 // Enum describes one possible value for a Restriction.
@@ -133,8 +134,9 @@ type ComplexType struct {
 // ComplexContent describes complex content within a complex type. Usually
 // for extending the complex type with fields from the complex content.
 type ComplexContent struct {
-	XMLName   xml.Name   `xml:"complexContent"`
-	Extension *Extension `xml:"extension"`
+	XMLName     xml.Name     `xml:"complexContent"`
+	Extension   *Extension   `xml:"extension"`
+	Restriction *Restriction `xml:"restriction"`
 }
 
 // Extension describes a complex content extension.
@@ -165,13 +167,14 @@ type Choice struct {
 
 // Attribute describes an attribute of a given type.
 type Attribute struct {
-	XMLName  xml.Name `xml:"attribute"`
-	Name     string   `xml:"name,attr"`
-	Ref      string   `xml:"ref,attr"`
-	Type     string   `xml:"type,attr"`
-	Min      int      `xml:"minOccurs,attr"`
-	Max      string   `xml:"maxOccurs,attr"` // can be # or unbounded
-	Nillable bool     `xml:"nillable,attr"`
+	XMLName   xml.Name `xml:"attribute"`
+	Name      string   `xml:"name,attr"`
+	Ref       string   `xml:"ref,attr"`
+	Type      string   `xml:"type,attr"`
+	ArrayType string   `xml:"arrayType,attr"`
+	Min       int      `xml:"minOccurs,attr"`
+	Max       string   `xml:"maxOccurs,attr"` // can be # or unbounded
+	Nillable  bool     `xml:"nillable,attr"`
 }
 
 // Element describes an element of a given type.

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1309,6 +1309,16 @@ func (ge *goEncoder) genGoStruct(w io.Writer, d *wsdl.Definitions, ct *wsdl.Comp
 			return nil
 		}
 	}
+	if ct.ComplexContent != nil {
+		restr := ct.ComplexContent.Restriction
+		if restr != nil && len(restr.Attributes) == 1 && restr.Attributes[0].ArrayType != "" {
+			fmt.Fprintf(w, "type %s struct {\n", name)
+			typ := strings.SplitN(trimns(restr.Attributes[0].ArrayType), "[", 2)[0]
+			fmt.Fprintf(w, "Items []*%s `xml:\"item,omitempty\" json:\"item,omitempty\" yaml:\"item,omitempty\"`\n", typ)
+			fmt.Fprintf(w, "}\n\n")
+			return nil
+		}
+	}
 	if c > 2 && len(ct.Attributes) == 0 {
 		fmt.Fprintf(w, "type %s struct {\n", name)
 		ge.genXMLName(w, d.TargetNamespace, name)

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1038,7 +1038,7 @@ func (ge *goEncoder) wsdl2goDefault(t string) string {
 		return `errors.New("not implemented")`
 	case "bool":
 		return "false"
-	case "int", "int64", "float64":
+	case "uint", "int", "int64", "float64":
 		return "0"
 	case "string":
 		return `""`

--- a/wsdlgo/encoder_test.go
+++ b/wsdlgo/encoder_test.go
@@ -55,6 +55,7 @@ var EncoderCases = []struct {
 	{F: "localimport.wsdl", G: "localimport.golden", E: nil},
 	{F: "localimport-url.wsdl", G: "localimport.golden", E: nil},
 	{F: "localimport_choice.wsdl", G: "localimport_choice.golden", E: nil},
+	{F: "arrayexample.wsdl", G: "arrayexample.golden", E: nil},
 }
 
 func NewTestServer(t *testing.T) *httptest.Server {

--- a/wsdlgo/testdata/arrayexample.golden
+++ b/wsdlgo/testdata/arrayexample.golden
@@ -1,0 +1,61 @@
+package stockquotesoapbinding
+
+import (
+	"github.com/fiorix/wsdl2go/soap"
+)
+
+// Namespace was auto-generated from WSDL.
+var Namespace = "http://example.com/stockquote.wsdl"
+
+// NewStockQuotePortType creates an initializes a StockQuotePortType.
+func NewStockQuotePortType(cli *soap.Client) StockQuotePortType {
+	return &stockQuotePortType{cli}
+}
+
+// StockQuotePortType was auto-generated from WSDL
+// and defines interface for the remote service. Useful for testing.
+type StockQuotePortType interface {
+	// GetTradePrices was auto-generated from WSDL.
+	GetTradePrices(tickerSymbol string) (*ArrayOfFloat, error)
+}
+
+// ArrayOfFloat was auto-generated from WSDL.
+type ArrayOfFloat struct {
+	Items []*float `xml:"item,omitempty" json:"item,omitempty" yaml:"item,omitempty"`
+}
+
+// Operation wrapper for GetTradePrices.
+// OperationGetTradePricesInput was auto-generated from WSDL.
+type OperationGetTradePricesInput struct {
+	TickerSymbol *string `xml:"tickerSymbol,omitempty" json:"tickerSymbol,omitempty" yaml:"tickerSymbol,omitempty"`
+}
+
+// Operation wrapper for GetTradePrices.
+// OperationGetTradePricesOutput was auto-generated from WSDL.
+type OperationGetTradePricesOutput struct {
+	Result *ArrayOfFloat `xml:"result,omitempty" json:"result,omitempty" yaml:"result,omitempty"`
+}
+
+// stockQuotePortType implements the StockQuotePortType interface.
+type stockQuotePortType struct {
+	cli *soap.Client
+}
+
+// GetTradePrices was auto-generated from WSDL.
+func (p *stockQuotePortType) GetTradePrices(tickerSymbol string) (*ArrayOfFloat, error) {
+	α := struct {
+		M OperationGetTradePricesInput `xml:"tns:GetTradePrices"`
+	}{
+		OperationGetTradePricesInput{
+			&tickerSymbol,
+		},
+	}
+
+	γ := struct {
+		M OperationGetTradePricesOutput `xml:"GetTradePricesResponse"`
+	}{}
+	if err := p.cli.RoundTripWithAction("http://example.com/GetTradePrices", α, &γ); err != nil {
+		return nil, err
+	}
+	return γ.M.Result, nil
+}

--- a/wsdlgo/testdata/arrayexample.wsdl
+++ b/wsdlgo/testdata/arrayexample.wsdl
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<!--
+This is Example 5. SOAP binding of request-response RPC operation over HTTP
+from the SOAP examples chapter. To focus solely on arrays, the date types have
+been removed.
+
+https://www.w3.org/TR/2001/NOTE-wsdl-20010315#_soap-e
+-->
+<definitions name="StockQuote"
+
+targetNamespace="http://example.com/stockquote.wsdl"
+          xmlns:tns="http://example.com/stockquote.wsdl"
+          xmlns:xsd="http://www.w3.org/2000/10/XMLSchema"
+          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+          xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+          xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+          xmlns="http://schemas.xmlsoap.org/wsdl/">
+
+    <types>
+       <xsd:schema xmlns="http://www.w3.org/2000/10/XMLSchema">
+           <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/" />
+           <xsd:import namespace="http://schemas.xmlsoap.org/wsdl/" />
+
+           <xsd:complexType name="ArrayOfFloat">
+              <xsd:complexContent>
+                  <xsd:restriction base="soapenc:Array">
+                      <xsd:attribute ref="soapenc:arrayType" wsdl:arrayType="xsd:float[]"/>
+                  </xsd:restriction>
+              </xsd:complexContent>
+           </xsd:complexType>
+       </xsd:schema>
+    </types>
+
+    <message name="GetTradePricesInput">
+        <part name="tickerSymbol" element="xsd:string"/>
+    </message>
+
+    <message name="GetTradePricesOutput">
+        <part name="result" type="tns:ArrayOfFloat"/>
+    </message>
+
+    <portType name="StockQuotePortType">
+        <operation name="GetTradePrices">
+           <input message="tns:GetTradePricesInput"/>
+           <output message="tns:GetTradePricesOutput"/>
+        </operation>
+    </portType>
+
+    <binding name="StockQuoteSoapBinding" type="tns:StockQuotePortType">
+        <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="GetTradePrices">
+           <soap:operation soapAction="http://example.com/GetTradePrices"/>
+           <input>
+               <soap:body use="encoded" namespace="http://example.com/stockquote"
+                          encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+           </input>
+           <output>
+               <soap:body use="encoded" namespace="http://example.com/stockquote"
+                          encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+           </output>
+        </operation>
+    </binding>
+
+    <service name="StockQuoteService">
+        <documentation>My first service</documentation>
+        <port name="StockQuotePort" binding="tns:StockQuoteBinding">
+           <soap:address location="http://example.com/stockquote"/>
+        </port>
+    </service>
+</definitions>


### PR DESCRIPTION
The unsigned integer fix speaks for itself.

The Post hook was added to allow me to capture the cookies that were added as a response as in an authentication call, the Pre hook already allowed me to add these cookies once authenticated.

The Array encoding implementation is pretty basic, close to the XML itself. It will add an Items array in the message structures in case of an array (rather than replacing the message struct with the actual array).