### PR TITLE
Fix complex content array restriction type

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1320,7 +1320,7 @@ func (ge *goEncoder) genGoStruct(w io.Writer, d *wsdl.Definitions, ct *wsdl.Comp
 		if restr != nil && len(restr.Attributes) == 1 && restr.Attributes[0].ArrayType != "" {
 			fmt.Fprintf(w, "type %s struct {\n", name)
 			typ := strings.SplitN(trimns(restr.Attributes[0].ArrayType), "[", 2)[0]
-			fmt.Fprintf(w, "Items []*%s `xml:\"item,omitempty\" json:\"item,omitempty\" yaml:\"item,omitempty\"`\n", typ)
+			fmt.Fprintf(w, "Items []%s `xml:\"item,omitempty\" json:\"item,omitempty\" yaml:\"item,omitempty\"`\n", ge.wsdl2goType(typ))
 			fmt.Fprintf(w, "}\n\n")
 			return nil
 		}

--- a/wsdlgo/testdata/arrayexample.golden
+++ b/wsdlgo/testdata/arrayexample.golden
@@ -21,7 +21,7 @@ type StockQuotePortType interface {
 
 // ArrayOfFloat was auto-generated from WSDL.
 type ArrayOfFloat struct {
-	Items []*float `xml:"item,omitempty" json:"item,omitempty" yaml:"item,omitempty"`
+	Items []float64 `xml:"item,omitempty" json:"item,omitempty" yaml:"item,omitempty"`
 }
 
 // Operation wrapper for GetTradePrices.


### PR DESCRIPTION
Hello,

I was using your library with a WSDL using array contentType restrictions, and I noticed the generated code had errors in it. The errors were all about the same thing : 

Originally generated code, with the error :
```go
type InvoiceitemArray struct {
	Items []*invoiceitem `...`
}

type Invoiceitem struct { ... }
```
As you may have noticed, the `Invoiceitem` struct has been generated with the correct name, but the type referenced in `InvoiceitemArray` lacks the capitalisation. While with another WSDL, the naming was right, but it used a different way to declare its arrays. 

Also, by using this fix, we get arrays of primitive types and not arrays of pointers to primitive types, which is, performance wise, a good thing. (while still getting pointers to composite types)

Source WSDL : [https://sr-pp.swissbilling.ch/EShopRequestV2Sec_DotNet.wsdl](https://sr-pp.swissbilling.ch/EShopRequestV2Sec_DotNet.wsdl) 

The important extract of this WSDL: 
```xml
<xsd:complexType name="invoiceitemArray">
	<xsd:complexContent>
	<xsd:restriction base="SOAP-ENC:Array">
		<xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:invoiceitem[]"/>
	</xsd:restriction>
	</xsd:complexContent>
</xsd:complexType>
```

I'm not really familiar with this code base, so please tell me if there's something wrong / I haven't seen. 

Thank you, Benjamin.