### PR TITLE
Add support for <simpleContent>

### DIFF
--- a/wsdl/types.go
+++ b/wsdl/types.go
@@ -125,10 +125,18 @@ type ComplexType struct {
 	Doc             string          `xml:"annotation>documentation"`
 	AllElements     []*Element      `xml:"all>element"`
 	ComplexContent  *ComplexContent `xml:"complexContent"`
+	SimpleContent   *SimpleContent  `xml:"simpleContent"`
 	Sequence        *Sequence       `xml:"sequence"`
 	Choice          *Choice         `xml:"choice"`
 	Attributes      []*Attribute    `xml:"attribute"`
 	TargetNamespace string
+}
+
+// SimpleContent describes simple content within a complex type.
+type SimpleContent struct {
+	XMLName     xml.Name     `xml:"simpleContent"`
+	Extension   *Extension   `xml:"extension"`
+	Restriction *Restriction `xml:"restriction"`
 }
 
 // ComplexContent describes complex content within a complex type. Usually

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1468,14 +1468,21 @@ func (ge *goEncoder) genSimpleContent(w io.Writer, d *wsdl.Definitions, ct *wsdl
 	if ct.SimpleContent == nil || ct.SimpleContent.Extension == nil {
 		return nil
 	}
+
 	ext := ct.SimpleContent.Extension
 	if ext.Base != "" {
-		base, exists := ge.ctypes[trimns(ext.Base)]
+		baseComplex, exists := ge.ctypes[trimns(ext.Base)]
 		if exists {
-			err := ge.genStructFields(w, d, base)
+			err := ge.genStructFields(w, d, baseComplex)
 			if err != nil {
 				return err
 			}
+		} else {
+			// otherwise it's a simple type
+			ge.genElementField(w, &wsdl.Element{
+				Type: trimns(ext.Base),
+				Name: "Content",
+			})
 		}
 	}
 
@@ -1604,6 +1611,7 @@ func (ge *goEncoder) writeComments(w io.Writer, typeName, comment string) {
 		if line == "" {
 			count, line = 2, "//"
 		}
+
 		count += len(word)
 		if count > 60 {
 			fmt.Fprintf(w, "%s %s\n", line, word)


### PR DESCRIPTION
Simple content is like... a simpler version of \<complexContent> within a
\<complexType>! This commit adds support for a \<simpleContent> tag with
extensions/restrictions.

I'm looking at using wsdl2go for a quick integration with NetSuite, but hit an immediate hurdle of not having \<simpleContent> be supported such that I could use the TokenPassportSignature element defined in https://webservices.netsuite.com/xsd/platform/v2018_1_0/core.xsd

I don't really know what I'm doing here, but this commit copies the approach to \<complexContent> and  strips down to the supported tags within \<simpleContent>. The thing I'm least certain of is the `c > 2 && len(ct.Attributes) == 0` pre-condition change.

With this change, and the above linked wsdl, you get output like:

```
type TokenPassport struct {
	Account     *string                 `xml:"account,omitempty" json:"account,omitempty" yaml:"account,omitempty"`
	ConsumerKey *string                 `xml:"consumerKey,omitempty" json:"consumerKey,omitempty" yaml:"consumerKey,omitempty"`
	Token       *string                 `xml:"token,omitempty" json:"token,omitempty" yaml:"token,omitempty"`
	Nonce       *string                 `xml:"nonce,omitempty" json:"nonce,omitempty" yaml:"nonce,omitempty"`
	Timestamp   *int64                  `xml:"timestamp,omitempty" json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
	Signature   *TokenPassportSignature `xml:"signature,omitempty" json:"signature,omitempty" yaml:"signature,omitempty"`
}

// TokenPassportSignature was auto-generated from WSDL.
type TokenPassportSignature struct {
	Content   *string `xml:"Content,omitempty" json:"Content,omitempty" yaml:"Content,omitempty"`
	Algorithm string `xml:"algorithm,attr,omitempty" json:"algorithm,attr,omitempty" yaml:"algorithm,attr,omitempty"`
}
```

(Where on `master` we hit the `c > 2 [...]` precondition and generate an empty struct instead).