### PR TITLE
operation paramters: resolve element names

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1386,7 +1386,18 @@ func (ge *goEncoder) genOpStructMessage(w io.Writer, d *wsdl.Definitions, name s
 	}
 
 	for _, part := range message.Parts {
-		wsdlType := part.Type
+		var wsdlType string
+		switch {
+		case part.Type != "":
+			wsdlType = part.Type
+		case part.Element != "":
+			elName := trimns(part.Element)
+			if el, ok := ge.elements[elName]; ok {
+				wsdlType = ge.wsdl2goType(trimns(el.Type))
+			} else {
+				wsdlType = ge.wsdl2goType(part.Element)
+			}
+		}
 
 		// Probably soap12
 		if wsdlType == "" {


### PR DESCRIPTION
When an operation has a message that refers to a part whose element name
differs from it's element type, you need to try and resolve that name rather
than taking the type of the part directly.

This is the same name resolution as done when generating the operation
parameters elsewhere.