### PR TITLE
Update wsdl:part messages to use XML name from referenced element

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Because of some [limitations](https://github.com/golang/go/issues/14407) of XML 
 
 Types supported:
 
+- [x] byte
 - [x] int
 - [x] long (int64)
 - [x] float (float64)

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -988,6 +988,8 @@ func (ge *goEncoder) wsdl2goType(t string) string {
 		return goSymbol(v)
 	}
 	switch strings.ToLower(v) {
+	case "byte", "unsignedbyte":
+		return "byte"
 	case "int":
 		return "int"
 	case "integer":

--- a/wsdlgo/testdata/arrayexample.golden
+++ b/wsdlgo/testdata/arrayexample.golden
@@ -16,7 +16,7 @@ func NewStockQuotePortType(cli *soap.Client) StockQuotePortType {
 // and defines interface for the remote service. Useful for testing.
 type StockQuotePortType interface {
 	// GetTradePrices was auto-generated from WSDL.
-	GetTradePrices(tickerSymbol string) (*ArrayOfFloat, error)
+	GetTradePrices(String string) (*ArrayOfFloat, error)
 }
 
 // ArrayOfFloat was auto-generated from WSDL.
@@ -42,12 +42,12 @@ type stockQuotePortType struct {
 }
 
 // GetTradePrices was auto-generated from WSDL.
-func (p *stockQuotePortType) GetTradePrices(tickerSymbol string) (*ArrayOfFloat, error) {
+func (p *stockQuotePortType) GetTradePrices(String string) (*ArrayOfFloat, error) {
 	α := struct {
 		M OperationGetTradePricesInput `xml:"tns:GetTradePrices"`
 	}{
 		OperationGetTradePricesInput{
-			&tickerSymbol,
+			&String,
 		},
 	}
 

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -16,7 +16,7 @@ func NewDataEndpointPortType(cli *soap.Client) DataEndpointPortType {
 // and defines interface for the remote service. Useful for testing.
 type DataEndpointPortType interface {
 	// GetData was auto-generated from WSDL.
-	GetData(parameters *GetData) (*GetDataResp, error)
+	GetData(GetData *GetData) (*GetDataResp, error)
 }
 
 // BaseReq was auto-generated from WSDL.
@@ -99,13 +99,13 @@ type GetDataResp struct {
 // Operation wrapper for GetData.
 // OperationGetDataReq was auto-generated from WSDL.
 type OperationGetDataReq struct {
-	Parameters *GetData `xml:"parameters,omitempty" json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	GetData *GetData `xml:"getData,omitempty" json:"getData,omitempty" yaml:"getData,omitempty"`
 }
 
 // Operation wrapper for GetData.
 // OperationGetDataResp was auto-generated from WSDL.
 type OperationGetDataResp struct {
-	Parameters *GetDataResp `xml:"parameters,omitempty" json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	GetDataResp *GetDataResp `xml:"getDataResp,omitempty" json:"getDataResp,omitempty" yaml:"getDataResp,omitempty"`
 }
 
 // dataEndpointPortType implements the DataEndpointPortType interface.
@@ -114,12 +114,12 @@ type dataEndpointPortType struct {
 }
 
 // GetData was auto-generated from WSDL.
-func (p *dataEndpointPortType) GetData(parameters *GetData) (*GetDataResp, error) {
+func (p *dataEndpointPortType) GetData(GetData *GetData) (*GetDataResp, error) {
 	α := struct {
 		OperationGetDataReq `xml:"ns:getData"`
 	}{
 		OperationGetDataReq{
-			parameters,
+			GetData,
 		},
 	}
 
@@ -129,5 +129,5 @@ func (p *dataEndpointPortType) GetData(parameters *GetData) (*GetDataResp, error
 	if err := p.cli.RoundTripWithAction("GetData", α, &γ); err != nil {
 		return nil, err
 	}
-	return γ.Parameters, nil
+	return γ.GetDataResp, nil
 }

--- a/wsdlgo/testdata/data_withkeyword.golden
+++ b/wsdlgo/testdata/data_withkeyword.golden
@@ -16,7 +16,7 @@ func NewDataEndpointPortType(cli *soap.Client) DataEndpointPortType {
 // and defines interface for the remote service. Useful for testing.
 type DataEndpointPortType interface {
 	// GetData was auto-generated from WSDL.
-	GetData(_return *GetData) (*GetDataResp, error)
+	GetData(GetData *GetData) (*GetDataResp, error)
 }
 
 // BaseReq was auto-generated from WSDL.
@@ -99,13 +99,13 @@ type GetDataResp struct {
 // Operation wrapper for GetData.
 // OperationGetDataReq was auto-generated from WSDL.
 type OperationGetDataReq struct {
-	Return *GetData `xml:"return,omitempty" json:"return,omitempty" yaml:"return,omitempty"`
+	GetData *GetData `xml:"getData,omitempty" json:"getData,omitempty" yaml:"getData,omitempty"`
 }
 
 // Operation wrapper for GetData.
 // OperationGetDataResp was auto-generated from WSDL.
 type OperationGetDataResp struct {
-	Return *GetDataResp `xml:"return,omitempty" json:"return,omitempty" yaml:"return,omitempty"`
+	GetDataResp *GetDataResp `xml:"getDataResp,omitempty" json:"getDataResp,omitempty" yaml:"getDataResp,omitempty"`
 }
 
 // dataEndpointPortType implements the DataEndpointPortType interface.
@@ -114,12 +114,12 @@ type dataEndpointPortType struct {
 }
 
 // GetData was auto-generated from WSDL.
-func (p *dataEndpointPortType) GetData(_return *GetData) (*GetDataResp, error) {
+func (p *dataEndpointPortType) GetData(GetData *GetData) (*GetDataResp, error) {
 	α := struct {
 		OperationGetDataReq `xml:"ns:getData"`
 	}{
 		OperationGetDataReq{
-			_return,
+			GetData,
 		},
 	}
 
@@ -129,5 +129,5 @@ func (p *dataEndpointPortType) GetData(_return *GetData) (*GetDataResp, error) {
 	if err := p.cli.RoundTripWithAction("GetData", α, &γ); err != nil {
 		return nil, err
 	}
-	return γ.Return, nil
+	return γ.GetDataResp, nil
 }

--- a/wsdlgo/testdata/localimport.golden
+++ b/wsdlgo/testdata/localimport.golden
@@ -16,7 +16,7 @@ func NewStockQuotePortType(cli *soap.Client) StockQuotePortType {
 // and defines interface for the remote service. Useful for testing.
 type StockQuotePortType interface {
 	// GetLastTradePrice was auto-generated from WSDL.
-	GetLastTradePrice(body *TradePriceRequest) (*TradePrice, error)
+	GetLastTradePrice(TradePriceRequest *TradePriceRequest) (*TradePrice, error)
 }
 
 // TradePrice was auto-generated from WSDL.
@@ -32,13 +32,13 @@ type TradePriceRequest struct {
 // Operation wrapper for GetLastTradePrice.
 // OperationGetLastTradePriceInput was auto-generated from WSDL.
 type OperationGetLastTradePriceInput struct {
-	Body *TradePriceRequest `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	TradePriceRequest *TradePriceRequest `xml:"TradePriceRequest,omitempty" json:"TradePriceRequest,omitempty" yaml:"TradePriceRequest,omitempty"`
 }
 
 // Operation wrapper for GetLastTradePrice.
 // OperationGetLastTradePriceOutput was auto-generated from WSDL.
 type OperationGetLastTradePriceOutput struct {
-	Body *TradePrice `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	TradePrice *TradePrice `xml:"TradePrice,omitempty" json:"TradePrice,omitempty" yaml:"TradePrice,omitempty"`
 }
 
 // stockQuotePortType implements the StockQuotePortType interface.
@@ -47,12 +47,12 @@ type stockQuotePortType struct {
 }
 
 // GetLastTradePrice was auto-generated from WSDL.
-func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradePrice, error) {
+func (p *stockQuotePortType) GetLastTradePrice(TradePriceRequest *TradePriceRequest) (*TradePrice, error) {
 	α := struct {
 		OperationGetLastTradePriceInput `xml:"tns:GetLastTradePrice"`
 	}{
 		OperationGetLastTradePriceInput{
-			body,
+			TradePriceRequest,
 		},
 	}
 
@@ -62,5 +62,5 @@ func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradeP
 	if err := p.cli.RoundTripWithAction("http://example.com/GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
 	}
-	return γ.Body, nil
+	return γ.TradePrice, nil
 }

--- a/wsdlgo/testdata/localimport_choice.golden
+++ b/wsdlgo/testdata/localimport_choice.golden
@@ -16,7 +16,7 @@ func NewStockQuotePortType(cli *soap.Client) StockQuotePortType {
 // and defines interface for the remote service. Useful for testing.
 type StockQuotePortType interface {
 	// GetLastTradePrice was auto-generated from WSDL.
-	GetLastTradePrice(body *TradePriceRequest) (*TradePrice, error)
+	GetLastTradePrice(TradePriceRequest *TradePriceRequest) (*TradePrice, error)
 }
 
 // TradePrice was auto-generated from WSDL.
@@ -39,7 +39,7 @@ type OperationGetLastTradePriceInput struct {
 // Operation wrapper for GetLastTradePrice.
 // OperationGetLastTradePriceOutput was auto-generated from WSDL.
 type OperationGetLastTradePriceOutput struct {
-	Body *TradePrice `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	TradePrice *TradePrice `xml:"TradePrice,omitempty" json:"TradePrice,omitempty" yaml:"TradePrice,omitempty"`
 }
 
 // stockQuotePortType implements the StockQuotePortType interface.
@@ -48,12 +48,12 @@ type stockQuotePortType struct {
 }
 
 // GetLastTradePrice was auto-generated from WSDL.
-func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradePrice, error) {
+func (p *stockQuotePortType) GetLastTradePrice(TradePriceRequest *TradePriceRequest) (*TradePrice, error) {
 	α := struct {
 		OperationGetLastTradePriceInput `xml:"tns:GetLastTradePrice"`
 	}{
 		OperationGetLastTradePriceInput{
-			body,
+			TradePriceRequest,
 		},
 	}
 
@@ -63,5 +63,5 @@ func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradeP
 	if err := p.cli.RoundTripWithAction("http://example.com/GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
 	}
-	return γ.Body, nil
+	return γ.TradePrice, nil
 }

--- a/wsdlgo/testdata/soap12wcf.golden
+++ b/wsdlgo/testdata/soap12wcf.golden
@@ -16,19 +16,19 @@ func NewTest(cli *soap.Client) Test {
 // and defines interface for the remote service. Useful for testing.
 type Test interface {
 	// HelloWorld was auto-generated from WSDL.
-	HelloWorld(parameters string) (string, error)
+	HelloWorld(HelloRequest string) (string, error)
 }
 
 // Operation wrapper for HelloWorld.
 // OperationHelloWorldMessageIn was auto-generated from WSDL.
 type OperationHelloWorldMessageIn struct {
-	Parameters *HelloRequest `xml:"parameters,omitempty" json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	HelloRequest *HelloRequest `xml:"HelloRequest,omitempty" json:"HelloRequest,omitempty" yaml:"HelloRequest,omitempty"`
 }
 
 // Operation wrapper for HelloWorld.
 // OperationHelloWorldMessageOut was auto-generated from WSDL.
 type OperationHelloWorldMessageOut struct {
-	Parameters *HelloResponse `xml:"parameters,omitempty" json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	HelloResponse *HelloResponse `xml:"HelloResponse,omitempty" json:"HelloResponse,omitempty" yaml:"HelloResponse,omitempty"`
 }
 
 // test implements the Test interface.
@@ -37,12 +37,12 @@ type test struct {
 }
 
 // HelloWorld was auto-generated from WSDL.
-func (p *test) HelloWorld(parameters string) (string, error) {
+func (p *test) HelloWorld(HelloRequest string) (string, error) {
 	α := struct {
 		OperationHelloWorldMessageIn `xml:"tns:HelloWorld"`
 	}{
 		OperationHelloWorldMessageIn{
-			&parameters,
+			&HelloRequest,
 		},
 	}
 
@@ -52,5 +52,5 @@ func (p *test) HelloWorld(parameters string) (string, error) {
 	if err := p.cli.RoundTripSoap12("http://example.com/Test/HelloWorldRequest", α, &γ); err != nil {
 		return "", err
 	}
-	return *γ.Parameters, nil
+	return *γ.HelloResponse, nil
 }

--- a/wsdlgo/testdata/w3example1.golden
+++ b/wsdlgo/testdata/w3example1.golden
@@ -16,7 +16,7 @@ func NewGetEndorsingBoarderPortType(cli *soap.Client) GetEndorsingBoarderPortTyp
 // and defines interface for the remote service. Useful for testing.
 type GetEndorsingBoarderPortType interface {
 	// GetEndorsingBoarder was auto-generated from WSDL.
-	GetEndorsingBoarder(body *GetEndorsingBoarder) (*GetEndorsingBoarderResponse, error)
+	GetEndorsingBoarder(GetEndorsingBoarder *GetEndorsingBoarder) (*GetEndorsingBoarderResponse, error)
 }
 
 // GetEndorsingBoarder was auto-generated from WSDL.
@@ -39,14 +39,14 @@ type GetEndorsingBoarderResponse struct {
 // OperationGetEndorsingBoarderRequest was auto-generated from
 // WSDL.
 type OperationGetEndorsingBoarderRequest struct {
-	Body *GetEndorsingBoarder `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	GetEndorsingBoarder *GetEndorsingBoarder `xml:"GetEndorsingBoarder,omitempty" json:"GetEndorsingBoarder,omitempty" yaml:"GetEndorsingBoarder,omitempty"`
 }
 
 // Operation wrapper for GetEndorsingBoarder.
 // OperationGetEndorsingBoarderResponse was auto-generated from
 // WSDL.
 type OperationGetEndorsingBoarderResponse struct {
-	Body *GetEndorsingBoarderResponse `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	GetEndorsingBoarderResponse *GetEndorsingBoarderResponse `xml:"GetEndorsingBoarderResponse,omitempty" json:"GetEndorsingBoarderResponse,omitempty" yaml:"GetEndorsingBoarderResponse,omitempty"`
 }
 
 // getEndorsingBoarderPortType implements the GetEndorsingBoarderPortType interface.
@@ -55,12 +55,12 @@ type getEndorsingBoarderPortType struct {
 }
 
 // GetEndorsingBoarder was auto-generated from WSDL.
-func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(body *GetEndorsingBoarder) (*GetEndorsingBoarderResponse, error) {
+func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(GetEndorsingBoarder *GetEndorsingBoarder) (*GetEndorsingBoarderResponse, error) {
 	α := struct {
 		OperationGetEndorsingBoarderRequest `xml:"es:GetEndorsingBoarder"`
 	}{
 		OperationGetEndorsingBoarderRequest{
-			body,
+			GetEndorsingBoarder,
 		},
 	}
 
@@ -70,5 +70,5 @@ func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(body *GetEndorsingBoar
 	if err := p.cli.RoundTripWithAction("http://www.snowboard-info.com/EndorsementSearch", α, &γ); err != nil {
 		return nil, err
 	}
-	return γ.Body, nil
+	return γ.GetEndorsingBoarderResponse, nil
 }

--- a/wsdlgo/testdata/w3example2.golden
+++ b/wsdlgo/testdata/w3example2.golden
@@ -16,13 +16,13 @@ func NewStockQuotePortType(cli *soap.Client) StockQuotePortType {
 // and defines interface for the remote service. Useful for testing.
 type StockQuotePortType interface {
 	// DestroySession was auto-generated from WSDL.
-	DestroySession(body *DestroySessionRequest) (*DestroySessionResponse, error)
+	DestroySession(DestroySessionRequest *DestroySessionRequest) (*DestroySessionResponse, error)
 
 	// GetLastTradePrice was auto-generated from WSDL.
-	GetLastTradePrice(body *TradePriceRequest) (*TradePrice, error)
+	GetLastTradePrice(TradePriceRequest *TradePriceRequest) (*TradePrice, error)
 
 	// GetSession was auto-generated from WSDL.
-	GetSession(body *GetSessionRequest) (*GetSessionResponse, error)
+	GetSession(GetSessionRequest *GetSessionRequest) (*GetSessionResponse, error)
 }
 
 // DestroySessionRequest was auto-generated from WSDL.
@@ -56,37 +56,37 @@ type TradePriceRequest struct {
 // Operation wrapper for DestroySession.
 // OperationDestroySessionInput was auto-generated from WSDL.
 type OperationDestroySessionInput struct {
-	Body *DestroySessionRequest `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	DestroySessionRequest *DestroySessionRequest `xml:"DestroySessionRequest,omitempty" json:"DestroySessionRequest,omitempty" yaml:"DestroySessionRequest,omitempty"`
 }
 
 // Operation wrapper for DestroySession.
 // OperationDestroySessionOutput was auto-generated from WSDL.
 type OperationDestroySessionOutput struct {
-	Body *DestroySessionResponse `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	DestroySessionResponse *DestroySessionResponse `xml:"DestroySessionResponse,omitempty" json:"DestroySessionResponse,omitempty" yaml:"DestroySessionResponse,omitempty"`
 }
 
 // Operation wrapper for GetLastTradePrice.
 // OperationGetLastTradePriceInput was auto-generated from WSDL.
 type OperationGetLastTradePriceInput struct {
-	Body *TradePriceRequest `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	TradePriceRequest *TradePriceRequest `xml:"TradePriceRequest,omitempty" json:"TradePriceRequest,omitempty" yaml:"TradePriceRequest,omitempty"`
 }
 
 // Operation wrapper for GetLastTradePrice.
 // OperationGetLastTradePriceOutput was auto-generated from WSDL.
 type OperationGetLastTradePriceOutput struct {
-	Body *TradePrice `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	TradePrice *TradePrice `xml:"TradePrice,omitempty" json:"TradePrice,omitempty" yaml:"TradePrice,omitempty"`
 }
 
 // Operation wrapper for GetSession.
 // OperationGetSessionInput was auto-generated from WSDL.
 type OperationGetSessionInput struct {
-	Body *GetSessionRequest `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	GetSessionRequest *GetSessionRequest `xml:"GetSessionRequest,omitempty" json:"GetSessionRequest,omitempty" yaml:"GetSessionRequest,omitempty"`
 }
 
 // Operation wrapper for GetSession.
 // OperationGetSessionOutput was auto-generated from WSDL.
 type OperationGetSessionOutput struct {
-	Body *GetSessionResponse `xml:"body,omitempty" json:"body,omitempty" yaml:"body,omitempty"`
+	GetSessionResponse *GetSessionResponse `xml:"GetSessionResponse,omitempty" json:"GetSessionResponse,omitempty" yaml:"GetSessionResponse,omitempty"`
 }
 
 // stockQuotePortType implements the StockQuotePortType interface.
@@ -95,12 +95,12 @@ type stockQuotePortType struct {
 }
 
 // DestroySession was auto-generated from WSDL.
-func (p *stockQuotePortType) DestroySession(body *DestroySessionRequest) (*DestroySessionResponse, error) {
+func (p *stockQuotePortType) DestroySession(DestroySessionRequest *DestroySessionRequest) (*DestroySessionResponse, error) {
 	α := struct {
 		OperationDestroySessionInput `xml:"tns:DestroySession"`
 	}{
 		OperationDestroySessionInput{
-			body,
+			DestroySessionRequest,
 		},
 	}
 
@@ -110,16 +110,16 @@ func (p *stockQuotePortType) DestroySession(body *DestroySessionRequest) (*Destr
 	if err := p.cli.RoundTripWithAction("http://example.com/DestroySession", α, &γ); err != nil {
 		return nil, err
 	}
-	return γ.Body, nil
+	return γ.DestroySessionResponse, nil
 }
 
 // GetLastTradePrice was auto-generated from WSDL.
-func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradePrice, error) {
+func (p *stockQuotePortType) GetLastTradePrice(TradePriceRequest *TradePriceRequest) (*TradePrice, error) {
 	α := struct {
 		OperationGetLastTradePriceInput `xml:"tns:GetLastTradePrice"`
 	}{
 		OperationGetLastTradePriceInput{
-			body,
+			TradePriceRequest,
 		},
 	}
 
@@ -129,16 +129,16 @@ func (p *stockQuotePortType) GetLastTradePrice(body *TradePriceRequest) (*TradeP
 	if err := p.cli.RoundTripWithAction("http://example.com/GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
 	}
-	return γ.Body, nil
+	return γ.TradePrice, nil
 }
 
 // GetSession was auto-generated from WSDL.
-func (p *stockQuotePortType) GetSession(body *GetSessionRequest) (*GetSessionResponse, error) {
+func (p *stockQuotePortType) GetSession(GetSessionRequest *GetSessionRequest) (*GetSessionResponse, error) {
 	α := struct {
 		OperationGetSessionInput `xml:"tns:GetSession"`
 	}{
 		OperationGetSessionInput{
-			body,
+			GetSessionRequest,
 		},
 	}
 
@@ -148,5 +148,5 @@ func (p *stockQuotePortType) GetSession(body *GetSessionRequest) (*GetSessionRes
 	if err := p.cli.RoundTripWithAction("http://example.com/GetSession", α, &γ); err != nil {
 		return nil, err
 	}
-	return γ.Body, nil
+	return γ.GetSessionResponse, nil
 }


### PR DESCRIPTION
Greetings! First of all, thanks for an awesome Go package! 

I am interfacing with a WSDL-based SOAP service that worked with an older version of your `wsdl2go` library. When I upgraded from `8f16131` to `c0bfd34`, our client started generating an XML request that the server now rejects. The reason for this is due to `<wsdl:part>` messages using the `part` name attribute instead of the referenced `element`'s name. 

Here is the relevant `<wsdl:part>` message snippet from our WSDL file: 
```
<wsdl:message name="IELDSubmissionService_Submit_InputMessage">
  <wsdl:part name="parameters" element="tns:Submit"/>
</wsdl:message>
```

The current wsdl2go master XML output (rejected by server): `<parameters><data><ELDIdentifier>...</parameters>`. 

The older wsdl2go output (accepted by server): `<Submit xmlns="http://www.fmcsa.dot.gov/schemas/FMCSA.ELD.Infrastructure"><data><ELDIdentifier>...</Submit>`

In other words, the XML tag is now `parameters` instead of `Submit` for the above WSDL snippet: 
```
type OperationIELDSubmissionService_Submit_InputMessage struct {
	Parameters *Submit `xml:"parameters,omitempty" json:"parameters,omitempty" yaml:"parameters,omitempty"`
}
```

I took a shot at a PR that fixes my particular use case, but I don't know enough about SOAP to know what the proper behavior for all `<wsdl:part>` tags should be. 