### PR TITLE
Add soap binding input namespace to encoder

### DIFF
--- a/wsdl/types.go
+++ b/wsdl/types.go
@@ -308,6 +308,7 @@ type SOAP11Operation struct {
 
 // BindingIO describes the IO binding of SOAP operations. See IO for details.
 type BindingIO struct {
-	Parts string `xml:"parts,attr"`
-	Use   string `xml:"use,attr"`
+	Parts     string `xml:"parts,attr"`
+	Use       string `xml:"use,attr"`
+	Namespace string `xml:"namespace,attr"`
 }

--- a/wsdlgo/testdata/arrayexample.golden
+++ b/wsdlgo/testdata/arrayexample.golden
@@ -44,11 +44,13 @@ type stockQuotePortType struct {
 // GetTradePrices was auto-generated from WSDL.
 func (p *stockQuotePortType) GetTradePrices(String string) (*ArrayOfFloat, error) {
 	α := struct {
-		M OperationGetTradePricesInput `xml:"tns:GetTradePrices"`
+		M         OperationGetTradePricesInput `xml:"tns:GetTradePrices"`
+		Namespace string                       `xml:"xmlns,attr,omitempty"`
 	}{
 		OperationGetTradePricesInput{
 			&String,
 		},
+		"http://example.com/stockquote",
 	}
 
 	γ := struct {

--- a/wsdlgo/testdata/memcache.golden
+++ b/wsdlgo/testdata/memcache.golden
@@ -95,11 +95,13 @@ type memoryServicePortType struct {
 // Get was auto-generated from WSDL.
 func (p *memoryServicePortType) Get(key string) (*GetResponse, error) {
 	α := struct {
-		M OperationGetRequest `xml:"tns:Get"`
+		M         OperationGetRequest `xml:"tns:Get"`
+		Namespace string              `xml:"xmlns,attr,omitempty"`
 	}{
 		OperationGetRequest{
 			&key,
 		},
+		"urn:examples:memoryservice",
 	}
 
 	γ := struct {
@@ -114,11 +116,13 @@ func (p *memoryServicePortType) Get(key string) (*GetResponse, error) {
 // GetMulti was auto-generated from WSDL.
 func (p *memoryServicePortType) GetMulti(keys *GetMultiRequest) (*GetMultiResponse, error) {
 	α := struct {
-		M OperationGetMultiRequest `xml:"tns:GetMulti"`
+		M         OperationGetMultiRequest `xml:"tns:GetMulti"`
+		Namespace string                   `xml:"xmlns,attr,omitempty"`
 	}{
 		OperationGetMultiRequest{
 			keys,
 		},
+		"urn:examples:memoryservice",
 	}
 
 	γ := struct {
@@ -133,11 +137,13 @@ func (p *memoryServicePortType) GetMulti(keys *GetMultiRequest) (*GetMultiRespon
 // Set was auto-generated from WSDL.
 func (p *memoryServicePortType) Set(info *SetRequest) (bool, error) {
 	α := struct {
-		M OperationSetRequest `xml:"tns:Set"`
+		M         OperationSetRequest `xml:"tns:Set"`
+		Namespace string              `xml:"xmlns,attr,omitempty"`
 	}{
 		OperationSetRequest{
 			info,
 		},
+		"urn:examples:memoryservice",
 	}
 
 	γ := struct {

--- a/wsdlgo/testdata/w3example1.golden
+++ b/wsdlgo/testdata/w3example1.golden
@@ -58,10 +58,12 @@ type getEndorsingBoarderPortType struct {
 func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(GetEndorsingBoarder *GetEndorsingBoarder) (*GetEndorsingBoarderResponse, error) {
 	α := struct {
 		OperationGetEndorsingBoarderRequest `xml:"es:GetEndorsingBoarder"`
+		Namespace                           string `xml:"xmlns,attr,omitempty"`
 	}{
 		OperationGetEndorsingBoarderRequest{
 			GetEndorsingBoarder,
 		},
+		"http://schemas.snowboard-info.com/EndorsementSearch.xsd",
 	}
 
 	γ := struct {


### PR DESCRIPTION
Passes the namespace in the soap binding input as an xmlns attribute.