### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The process is this:
 
 Example:
 
-```
+```go
 import (
 	"/path/to/generated/example"
 


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.