### PR TITLE
Handle nil function input / output

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -10,10 +10,10 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"log"
 	"go/parser"
 	"go/token"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -1382,8 +1382,12 @@ func (ge *goEncoder) genGoOpStruct(w io.Writer, d *wsdl.Definitions, bo *wsdl.Bi
 		}
 	}
 
-	// Output messages are always required
-	ge.genOpStructMessage(w, d, name, ge.messages[trimns(ge.funcs[bo.Name].Output.Message)])
+	if function.Output == nil {
+		log.Printf("function output is nil! %v is %v", name, function)
+	} else {
+		// Output messages are always required
+		ge.genOpStructMessage(w, d, name, ge.messages[trimns(ge.funcs[bo.Name].Output.Message)])
+	}
 
 	return nil
 }

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"github.com/labstack/gommon/log"
+	"log"
 	"go/parser"
 	"go/token"
 	"io"
@@ -1370,7 +1370,7 @@ func (ge *goEncoder) genGoOpStruct(w io.Writer, d *wsdl.Definitions, bo *wsdl.Bi
 	function := ge.funcs[name]
 
 	if function.Input == nil {
-		log.Warnf("function input is nil! %v is %v", name, function)
+		log.Printf("function input is nil! %v is %v", name, function)
 	} else {
 		message := trimns(function.Input.Message)
 		inputMessage := ge.messages[message]


### PR DESCRIPTION
Without this commit, the attached WSDL causes a fatal crash due to a nil value in `ge.funcs[name].Input` that is dereferenced inside of `genGoOpStruct`.

This PR fixes #96, 

[wsd.zip](https://github.com/fiorix/wsdl2go/files/4399108/wsd.zip)
