### PR TITLE
Fix one-way operation that has no response

### DIFF
--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -743,7 +743,7 @@ func (ge *goEncoder) writeSOAPFunc(w io.Writer, d *wsdl.Definitions, op *wsdl.Op
 	if len(out) > 0 && op.Output != nil {
 		operationOutputDataType = ge.sanitizedOperationsType(ge.messages[trimns(op.Output.Message)].Name)
 	} else if rpcStyle {
-		operationInputDataType = "struct{}"
+		operationOutputDataType = "struct{}"
 	}
 
 	soapFunctionName := "RoundTripSoap12"


### PR DESCRIPTION
Due to a typo the generated code of an one-way operation is invalid.
The input data type of the operation is set to `struct{}`, even if there are input parameters.
Instead, the output data type must be `struct{}`. 